### PR TITLE
update logo url

### DIFF
--- a/frontend/src/components/Footer/Footer.tsx
+++ b/frontend/src/components/Footer/Footer.tsx
@@ -28,7 +28,7 @@ export default class Footer extends React.Component<FooterContent> {
             Créé et diffusé avec
           </span>
           <a href='https://www.mongulu.cm' target='_blank' rel='noreferrer'>
-            <img src="https://www.mongulu.cm/public/logo.png" alt="Créer et diffuser" className="h-10" />
+            <img src="https://images.mongulu.cm/logo.jpeg" alt="Créer et diffuser" className="h-10" />
           </a>
         </div>
       </footer>


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated the footer logo URL to https://images.mongulu.cm/logo.jpeg to fix the broken image and load it from the correct domain. This restores the brand logo in the footer.

<!-- End of auto-generated description by cubic. -->

